### PR TITLE
Adds campaign to Replicant values

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ You will need to have an appropriate version of NodeCG installed to use it.
 
 ```
 {
-	"tiltify_api_key": "KEY_HERE",
-	"tiltify_campaign_id": "CAMPAIGN_HERE"
+	"api_key": "KEY_HERE",
+	"campaign_id": "CAMPAIGN_HERE"
 }
 ```
 
@@ -28,7 +28,7 @@ Available Replicants from the Tiltify API:
 - [X] `donations`
 - [X] `challenges`
 - [X] `rewards`
-- [ ] `campaign`: (Coming soon)
+- [X] `campaign`
 
 The replicants convert results from the Tiltify API into objects, and more information on the exact format of the data from these replicants can be found in the [Tiltify API docs](https://tiltify.github.io/api/).
 

--- a/configschema.json
+++ b/configschema.json
@@ -2,11 +2,11 @@
 	"$schema": "http://json-schema.org/draft-04/schema#",
 	"type": "object",
 	"properties": {
-		"tiltify_api_key": {
+		"api_key": {
 			"type": "string",
 			"default": ""
 		},
-		"tiltify_campaign_id": {
+		"campaign_id": {
 			"type": "string",
 			"default": ""
 		}

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,9 @@
 'use strict'
 
 module.exports = function (nodecg) {
+  var campaignRep = nodecg.Replicant('campaign', {
+    defaultValue: {}
+  })
   var donationsRep = nodecg.Replicant('donations', {
     defaultValue: []
   })
@@ -25,20 +28,28 @@ module.exports = function (nodecg) {
 
   var TiltifyClient = require('tiltify-api-client')
 
-  if (nodecg.bundleConfig.tiltify_api_key === '') {
-    nodecg.log.info('Please set tiltify_api_key in cfg/nodecg-tiltify.json')
+  if (nodecg.bundleConfig.api_key === '') {
+    nodecg.log.info('Please set api_key in cfg/nodecg-tiltify.json')
     return
   }
 
-  if (nodecg.bundleConfig.tiltify_campaign_id === '') {
-    nodecg.log.info('Please set tiltify_campaign_id in cfg/nodecg-tiltify.json')
+  if (nodecg.bundleConfig.campaign_id === '') {
+    nodecg.log.info('Please set campaign_id in cfg/nodecg-tiltify.json')
     return
   }
 
-  var client = new TiltifyClient(nodecg.bundleConfig.tiltify_api_key)
+  var client = new TiltifyClient(nodecg.bundleConfig.api_key)
+
+  async function askTiltifyForCampaign () {
+    client.Campaigns.get(nodecg.bundleConfig.campaign_id, function (campaign) {
+      if (JSON.stringify(campaign.value) !== JSON.stringify(campaign)) {
+        campaignRep.value = campaign
+      }
+    })
+  }
 
   async function askTiltifyForDonations () {
-    client.Campaigns.getRecentDonations(nodecg.bundleConfig.tiltify_campaign_id, function (donations) {
+    client.Campaigns.getRecentDonations(nodecg.bundleConfig.campaign_id, function (donations) {
       for (let i = 0; i < donations.length; i++) {
         var found = donationsRep.value.find(function (element) {
           return element.id === donations[i].id
@@ -53,7 +64,7 @@ module.exports = function (nodecg) {
   }
 
   async function askTiltifyForAllDonations () {
-    client.Campaigns.getDonations(nodecg.bundleConfig.tiltify_campaign_id, function (alldonations) {
+    client.Campaigns.getDonations(nodecg.bundleConfig.campaign_id, function (alldonations) {
       if (JSON.stringify(allDonationsRep.value) !== JSON.stringify(alldonations)) {
         allDonationsRep.value = alldonations
       }
@@ -61,7 +72,7 @@ module.exports = function (nodecg) {
   }
 
   async function askTiltifyForPolls () {
-    client.Campaigns.getPolls(nodecg.bundleConfig.tiltify_campaign_id, function (polls) {
+    client.Campaigns.getPolls(nodecg.bundleConfig.campaign_id, function (polls) {
       if (JSON.stringify(pollsRep.value) !== JSON.stringify(polls)) {
         pollsRep.value = polls
       }
@@ -69,7 +80,7 @@ module.exports = function (nodecg) {
   }
 
   async function askTiltifyForSchedule () {
-    client.Campaigns.getSchedule(nodecg.bundleConfig.tiltify_campaign_id, function (schedule) {
+    client.Campaigns.getSchedule(nodecg.bundleConfig.campaign_id, function (schedule) {
       if (JSON.stringify(scheduleRep.value) !== JSON.stringify(schedule)) {
         scheduleRep.value = schedule
       }
@@ -77,7 +88,7 @@ module.exports = function (nodecg) {
   }
 
   async function askTiltifyForChallenges () {
-    client.Campaigns.getChallenges(nodecg.bundleConfig.tiltify_campaign_id, function (challenges) {
+    client.Campaigns.getChallenges(nodecg.bundleConfig.campaign_id, function (challenges) {
       if (JSON.stringify(challengesRep.value) !== JSON.stringify(challenges)) {
         challengesRep.value = challenges
       }
@@ -85,7 +96,7 @@ module.exports = function (nodecg) {
   }
 
   async function askTiltifyForRewards () {
-    client.Campaigns.getRewards(nodecg.bundleConfig.tiltify_campaign_id, function (rewards) {
+    client.Campaigns.getRewards(nodecg.bundleConfig.campaign_id, function (rewards) {
       if (JSON.stringify(rewardsRep.value) !== JSON.stringify(rewards)) {
         rewardsRep.value = rewards
       }
@@ -93,7 +104,7 @@ module.exports = function (nodecg) {
   }
 
   async function askTiltifyForTotal () {
-    client.Campaigns.get(nodecg.bundleConfig.tiltify_campaign_id, function (campaign) {
+    client.Campaigns.get(nodecg.bundleConfig.campaign_id, function (campaign) {
       if (campaignTotalRep.value !== parseFloat(campaign.amountRaised)) {
         campaignTotalRep.value = parseFloat(campaign.amountRaised)
       }
@@ -101,6 +112,7 @@ module.exports = function (nodecg) {
   }
 
   function askTiltify () {
+    askTiltifyForCampaign()
     askTiltifyForDonations()
     askTiltifyForPolls()
     askTiltifyForTotal()

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
   "name": "nodecg-tiltify",
-  "version": "0.0.0",
-  "description": "Tiltify API Client",
+  "version": "1.0.0",
+  "description": "Lets other bundles query the Tiltify API on behalf of a Tiltify App",
   "homepage": "https://github.com/daniellockard/nodecg-tiltify",
-  "author": {
+  "contributors": [{
     "name": "Danny Lockard",
-    "email": "danielhlockard@gmail.com",
-    "url": ""
-  },
+    "email": "danielhlockard@gmail.com"
+  }, {
+    "name": "Matt Haden",
+    "url": "https://github.com/Forceh91"
+  }, {
+    "name": "Nick T",
+    "email": "me@nt3rp.io",
+    "url": "https://nt3rp.io"
+  }],
   "files": [
     "extension.js"
   ],

--- a/schemas/campaign.json
+++ b/schemas/campaign.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"type": "object"
+}


### PR DESCRIPTION
- Simplifies configuration (removes redundant `tiltify`)
- Adds schema for new replicant
- Updates docs + package.json
- Bumps version to `1.0.0` (seems to be feature complete, but API key change technically breaks previous installs)